### PR TITLE
use docker:generic runner, and run ldconfig at the end

### DIFF
--- a/testbed/Dockerfile
+++ b/testbed/Dockerfile
@@ -1,0 +1,56 @@
+FROM golang:1.14.4-buster AS builder
+
+# PLAN_DIR is the location containing the plan source inside the container.
+ENV PLAN_DIR /plan
+
+# SDK_DIR is the location containing the (optional) sdk source inside the container.
+ENV SDK_DIR /sdk
+
+# Install brotli
+RUN apt-get update && apt-get install -y cmake && git clone https://github.com/google/brotli && cd brotli && mkdir out && cd out && ../configure-cmake && make && make test && make install
+
+# Delete any prior artifacts, if this is a cached image.
+RUN rm -rf ${PLAN_DIR} ${SDK_DIR} /testground_dep_list
+
+# TESTPLAN_EXEC_PKG is the executable package of the testplan to build.
+# The image will build that package only.
+ARG TESTPLAN_EXEC_PKG="."
+
+# GO_PROXY is the go proxy that will be used, or direct by default.
+ARG GO_PROXY=direct
+
+# BUILD_TAGS is either nothing, or when expanded, it expands to "-tags <comma-separated build tags>"
+ARG BUILD_TAGS
+
+# TESTPLAN_EXEC_PKG is the executable package within this test plan we want to build. 
+ENV TESTPLAN_EXEC_PKG ${TESTPLAN_EXEC_PKG}
+
+# We explicitly set GOCACHE under the /go directory for more tidiness.
+ENV GOCACHE /go/cache
+
+# Copy only go.mod files and download deps, in order to leverage Docker caching.
+COPY /plan/go.mod ${PLAN_DIR}/go.mod
+
+# Download deps.
+RUN echo "Using go proxy: ${GO_PROXY}" \
+    && cd ${PLAN_DIR} \
+    && go env -w GOPROXY="${GO_PROXY}" \
+    && go mod download
+
+# Now copy the rest of the source and run the build.
+COPY . /
+
+RUN cd ${PLAN_DIR} \
+    && go env -w GOPROXY="${GO_PROXY}" \
+    && GOOS=linux GOARCH=amd64 go build -o ${PLAN_DIR}/testplan.bin ${BUILD_TAGS} ${TESTPLAN_EXEC_PKG}
+
+# Store module dependencies
+RUN cd ${PLAN_DIR} \
+  && go list -m all > /testground_dep_list
+
+RUN mv ${PLAN_DIR}/testplan.bin /testplan
+
+RUN ldconfig
+
+EXPOSE 6060
+ENTRYPOINT [ "/testplan"]

--- a/testbed/compositions/rfc_k8s.toml
+++ b/testbed/compositions/rfc_k8s.toml
@@ -1,0 +1,30 @@
+[metadata]
+name    = "rfcBBL103A"
+author  = "adlrocha"
+
+[global]
+plan    = "testbed"
+case    = "ipfs-transfer"
+builder = "docker:generic"
+runner  = "cluster:k8s"
+
+total_instances = 6
+
+[global.build_config]
+  push_registry=true
+  go_proxy_mode="remote"
+  go_proxy_url="http://localhost:8081"
+  registry_type="aws"
+
+[[groups]]
+id = "nodes"
+instances = { count = 6 }
+
+    [groups.run]
+        [groups.run.test_params]
+            run_count = "5"
+            leech_count="15"
+            max_connection_rate="100"
+            file_size="15728640,31457280,47185920,57671680"
+
+    # test_params = { run_count = 5, leech_count = 15, max_connection_rate=100, input_data="random", file_size=[15728640,31457280,47185920,57671680]}

--- a/testbed/compositions/rfc_local.toml
+++ b/testbed/compositions/rfc_local.toml
@@ -1,0 +1,24 @@
+[metadata]
+name    = "rfcBBL103A"
+author  = "adlrocha"
+
+[global]
+plan    = "testbed"
+case    = "ipfs-transfer"
+builder = "docker:generic"
+runner  = "local:docker"
+
+total_instances = 6
+
+[[groups]]
+id = "nodes"
+instances = { count = 6 }
+
+    [groups.run]
+        [groups.run.test_params]
+            run_count = "5"
+            leech_count="15"
+            max_connection_rate="100"
+            file_size="15728640,31457280,47185920,57671680"
+
+    # test_params = { run_count = 5, leech_count = 15, max_connection_rate=100, input_data="random", file_size=[15728640,31457280,47185920,57671680]}

--- a/testbed/manifest.toml
+++ b/testbed/manifest.toml
@@ -6,8 +6,8 @@ go_version = "1.14"
 module_path = "github.com/ipfs/test-plans/beyond-bitswap"
 exec_pkg = "."
 
-[extra_sources]
-  "docker:go" = ["../datasets"]
+# [extra_sources]
+#   "docker:go" = ["../datasets"]
 
 # extra_sources = { "exec:go" = ["./scripts/inputData"] }
 


### PR DESCRIPTION
This PR is adding 2 compositions that use the `docker:generic` builder - one for `local:docker` and one for `cluster:k8s`.