### PR TITLE
Wait for graphsync finish, preventing early node shutdown

### DIFF
--- a/testbed/testbed/test/graphsyncTransfer.go
+++ b/testbed/testbed/test/graphsyncTransfer.go
@@ -155,6 +155,11 @@ func GraphsyncTransfer(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 				cancel()
 			}
 
+			// Wait for all leeches to have downloaded the data from seeds
+			err = signalAndWaitForAll("transfer-complete-" + runID)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
# Goals

I had trouble initially getting graphsync tests to run -- because the leech node appeared to shutdown immediately. Then I noticed that the ipfs transfer test was making both nodes wait before they moved to the next file. So I added that to the graphsync test code and it appeared to fix the problem.

# Implemenation

Make sure that all nodes on each testplan signal and wait for the others nodes to finish before going on to the next file in the test.