### PR TITLE
Fix IPFS memory cleanup

### DIFF
--- a/testbed/testbed/test/transfer.go
+++ b/testbed/testbed/test/transfer.go
@@ -67,7 +67,7 @@ func Transfer(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 
 		switch t.nodetp {
 		case utils.Seed:
-			err = t.addPublishFile(ctx, pIndex, testParams.File, runenv, testvars)
+			rootCid, err = t.addPublishFile(ctx, pIndex, testParams.File, runenv, testvars)
 		case utils.Leech:
 			rootCid, err = t.readFile(ctx, pIndex, runenv, testvars)
 		}
@@ -88,7 +88,7 @@ func Transfer(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 			case utils.Seed:
 				err = t.runTCPServer(ctx, pIndex, 0, testParams.File, runenv, testvars)
 			case utils.Leech:
-				tcpFetch, err = t.runTCPFetch(ctx, pIndex, 0,  runenv, testvars)
+				tcpFetch, err = t.runTCPFetch(ctx, pIndex, 0, runenv, testvars)
 			}
 			if err != nil {
 				return err
@@ -150,6 +150,7 @@ func Transfer(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 							runenv.RecordMessage("Error fetching data: %w", err)
 							leechFails++
 						} else {
+							runenv.RecordMessage("Fetch complete, proceeding")
 							err = files.WriteTo(rcvFile, "/tmp/"+strconv.Itoa(t.tpindex)+time.Now().String())
 							if err != nil {
 								cancel()
@@ -182,12 +183,12 @@ func Transfer(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 			}
 			runenv.RecordMessage("Finishing emitting metrics. Starting to clean...")
 
-			err = t.cleanupRun(ctx, runenv)
+			err = t.cleanupRun(ctx, rootCid, runenv)
 			if err != nil {
 				return err
 			}
 		}
-		err = t.cleanupFile(ctx)
+		err = t.cleanupFile(ctx, rootCid)
 		if err != nil {
 			return err
 		}

--- a/testbed/testbed/utils/bitswap.go
+++ b/testbed/testbed/utils/bitswap.go
@@ -107,7 +107,7 @@ func (n *BitswapNode) Add(ctx context.Context, fileNode files.Node) (cid.Cid, er
 	return ipldNode.Cid(), nil
 }
 
-func (n *BitswapNode) ClearDatastore(ctx context.Context) error {
+func (n *BitswapNode) ClearDatastore(ctx context.Context, _ cid.Cid) error {
 	return ClearBlockstore(ctx, n.blockStore)
 }
 

--- a/testbed/testbed/utils/graphsync.go
+++ b/testbed/testbed/utils/graphsync.go
@@ -32,7 +32,7 @@ type GraphsyncNode struct {
 	h             host.Host
 	totalSent     uint64
 	totalReceived uint64
-	numSeeds int
+	numSeeds      int
 }
 
 func CreateGraphsyncNode(ctx context.Context, h host.Host, bstore blockstore.Blockstore, numSeeds int) (*GraphsyncNode, error) {
@@ -72,7 +72,7 @@ func (n *GraphsyncNode) Add(ctx context.Context, fileNode files.Node) (cid.Cid, 
 	return ipldNode.Cid(), nil
 }
 
-func (n *GraphsyncNode) ClearDatastore(ctx context.Context) error {
+func (n *GraphsyncNode) ClearDatastore(ctx context.Context, rootCid cid.Cid) error {
 	return ClearBlockstore(ctx, n.blockStore)
 }
 

--- a/testbed/testbed/utils/node.go
+++ b/testbed/testbed/utils/node.go
@@ -19,7 +19,7 @@ type PeerInfo struct {
 type Node interface {
 	Add(ctx context.Context, file files.Node) (cid.Cid, error)
 	Fetch(ctx context.Context, cid cid.Cid, peers []PeerInfo) (files.Node, error)
-	ClearDatastore(ctx context.Context) error
+	ClearDatastore(ctx context.Context, rootCid cid.Cid) error
 	EmitMetrics(recorder MetricsRecorder) error
 	Host() host.Host
 	DAGService() ipld.DAGService


### PR DESCRIPTION
# Goals

This adds back in a corrected version of CleanDatastore for IPFS

# Implementation

Rather than simply deleting all keys in the datastore, we instead unpin and then delete the DAG that starts with the RootCID, using clean IPFS APIs. It seems to work.

This also required passing the root CID into clearDatastore, which required a couple other changes