### PR TITLE
Fix Host Close panic and support Node Type in Jupyter

### DIFF
--- a/testbed/testbed/scripts/ui.py
+++ b/testbed/testbed/scripts/ui.py
@@ -4,6 +4,7 @@ import utils
 class Layout:
     def __init__(self):
         self.testcase = widgets.Text(description="Testcase")
+        self.protocol = widgets.Text(description="Protocol")
         self.input_data = widgets.Text(description="Input Data Type")
         self.file_size = widgets.Text(description="File Size")
         self.data_dir = widgets.Text(description="Files Directory")
@@ -35,14 +36,16 @@ class Layout:
         self.grid[2, 0] = self.file_size
         self.grid[3, 0] = self.data_dir
         self.grid[4, 0] = self.run_count
+        self.grid[5, 0] = self.bandwidth_mb
+        self.grid[6, 0] = self.protocol
+        self.grid[7, 0] = self.runButton
+
         self.grid[0, 1] = self.n_nodes
         self.grid[1, 1] = self.n_leechers
         self.grid[2, 1] = self.n_passive
         self.grid[3, 1] = self.churn_rate
         self.grid[4, 1] = self.isDocker
-        self.grid[5, 0] = self.bandwidth_mb
         self.grid[5, 1] = self.latency_ms
-        self.grid[6, 0] = self.runButton
         self.grid[6, 1] = self.jitter_pct
         self.grid[7, 1] = self.tcpEnabled
 

--- a/testbed/testbed/scripts/utils.py
+++ b/testbed/testbed/scripts/utils.py
@@ -72,6 +72,7 @@ def process_layout_config(layout):
         " -tp bandwidth_mb=" + str(layout.bandwidth_mb.value) + \
         " -tp latency_ms=" + str(layout.latency_ms.value) + \
         " -tp jitter_pct=" + str(layout.jitter_pct.value) + \
+        " -tp node_type=" + layout.protocol.value + \
         " -tp enable_tcp=" + tcpFlag
 
     return cmd

--- a/testbed/testbed/test/common.go
+++ b/testbed/testbed/test/common.go
@@ -260,7 +260,7 @@ func (t *TestData) readFile(ctx context.Context, fIndex int, runenv *runtime.Run
 
 func (t *TestData) runTCPServer(ctx context.Context, fIndex int, runNum int, f utils.TestFile, runenv *runtime.RunEnv, testvars *TestVars) error {
 	// TCP variables
-	tcpAddrTopic := getTCPAddrTopic(fIndex,  runNum)
+	tcpAddrTopic := getTCPAddrTopic(fIndex, runNum)
 	runenv.RecordMessage("Starting TCP server in seed")
 
 	// Start TCP server for file
@@ -289,7 +289,7 @@ func (t *TestData) runTCPServer(ctx context.Context, fIndex int, runNum int, f u
 
 func (t *TestData) runTCPFetch(ctx context.Context, fIndex int, runNum int, runenv *runtime.RunEnv, testvars *TestVars) (int64, error) {
 	// TCP variables
-	tcpAddrTopic := getTCPAddrTopic(fIndex,  runNum)
+	tcpAddrTopic := getTCPAddrTopic(fIndex, runNum)
 	tcpAddrCh := make(chan *string, 1)
 	if _, err := t.client.Subscribe(ctx, tcpAddrTopic, tcpAddrCh); err != nil {
 		return 0, fmt.Errorf("Failed to subscribe to tcpServerTopic %w", err)
@@ -383,7 +383,7 @@ func (t *NodeTestData) cleanupFile(ctx context.Context) error {
 }
 
 func (t *NodeTestData) close() error {
-	if t.host != nil {
+	if t.host == nil {
 		return nil
 	}
 	return (*t.host).Close()


### PR DESCRIPTION
@adlrocha 

We need the `NodeType` param in Jupyter to support different protocols like Graphsync, Libp2p etc.
Also, I think the `plot_messages` ONLY works for `Bitswap`. Please can you make the stuff about 'Block Sent' etc optional in there ?